### PR TITLE
Allows "unsupported" games to support Open...Folder shortcuts

### DIFF
--- a/src/gameSupport.ts
+++ b/src/gameSupport.ts
@@ -1,5 +1,6 @@
 import { app as appIn, remote } from 'electron';
 import * as path from 'path';
+import { IGame } from 'vortex-api/lib/types/api';
 
 const app = remote?.app || appIn;
 
@@ -54,10 +55,16 @@ const gameSupport: { [gameId: string]: IGameSupport } = {
   },
 };
 
-export function settingsPath(gameMode: string): string {
-  return gameSupport[gameMode]?.settingsPath?.();
+export function settingsPath(game: IGame): string {
+  const knownPath = gameSupport[game.id]?.settingsPath?.();
+  return knownPath != undefined
+    ? knownPath
+    : game.details?.settingsPath?.();
 }
 
-export function appDataPath(gameMode: string): string {
-  return gameSupport[gameMode]?.appDataPath?.();
+export function appDataPath(game: IGame): string {
+  const knownPath = gameSupport[game.id]?.appDataPath?.();
+  return knownPath != undefined
+    ? knownPath
+    : game.details?.appDataPath?.();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { settingsPath, appDataPath } from './gameSupport';
 import Promise from 'bluebird';
 import * as path from 'path';
 import { fs, selectors, types, util } from 'vortex-api';
+import { IGame } from 'vortex-api/lib/types/api';
 
 function init(context: types.IExtensionContext) {
   context.registerAction('mod-icons', 300, 'open-ext', {},
@@ -47,29 +48,29 @@ function init(context: types.IExtensionContext) {
   context.registerAction('mod-icons', 300, 'open-ext', {},
                          'Open Game Settings Folder', () => {
     const state = context.api.getState();
-    const gameMode = selectors.activeGameId(state);
-    const target = settingsPath(gameMode);
+    const game = selectors.currentGame(state) as IGame;
+    const target = settingsPath(game);
     if (target !== undefined) {
       openPath(target);
     }
   }, () => {
     const state = context.api.getState();
-    const gameMode = selectors.activeGameId(state);
-    return settingsPath(gameMode) !== undefined;
+    const game = selectors.currentGame(state) as IGame;
+    return settingsPath(game) !== undefined;
   });
 
   context.registerAction('mod-icons', 300, 'open-ext', {},
                          'Open Game Application Data Folder', () => {
     const state = context.api.getState();
-    const gameMode = selectors.activeGameId(state);
-    const target = appDataPath(gameMode);
+    const game = selectors.currentGame(state) as IGame;
+    const target = appDataPath(game);
     if (target !== undefined) {
       openPath(target);
     }
   }, () => {
     const state = context.api.getState();
-    const gameMode = selectors.activeGameId(state);
-    return appDataPath(gameMode) !== undefined;
+    const game = selectors.currentGame(state) as IGame;
+    return appDataPath(game) !== undefined;
   });
 
   context.registerAction('mods-action-icons', 100, 'open-ext', {},


### PR DESCRIPTION
This allows a fallback for "unsupported" (i.e. non-hardcoded) games to optionally include a function in their `details` object during registration that can provide the "Settings" and "Application Data" folders.

As far as I can tell, this preserves the original behaviour across both supported and unsupported games *unless* a game includes a `settingsPath` and/or `appDataPath` function in its `details` object.